### PR TITLE
HTML entities to Unicode characters

### DIFF
--- a/lib/unitsml/prefix.rb
+++ b/lib/unitsml/prefix.rb
@@ -30,7 +30,11 @@ module Unitsml
     end
 
     def to_mathml
-      prefixes_symbols["html"]
+      Utility.string_to_html_entity(
+        Utility.html_entity_to_unicode(
+          prefixes_symbols["html"]
+        ),
+      )
     end
 
     def to_latex

--- a/lib/unitsml/utility.rb
+++ b/lib/unitsml/utility.rb
@@ -306,6 +306,19 @@ module Unitsml
         nodes&.each { |node| element << node unless node.nil? }
         element
       end
+
+      def string_to_html_entity(string)
+        entities = HTMLEntities.new
+        entities.encode(
+          string.frozen? ? string : string.force_encoding('UTF-8'),
+          :hexadecimal,
+        )
+      end
+
+      def html_entity_to_unicode(string)
+        entities = HTMLEntities.new
+        entities.decode(string)
+      end
     end
   end
 end

--- a/spec/unitsml/conv/mathml_spec.rb
+++ b/spec/unitsml/conv/mathml_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       <<~MATHML
         <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-          <mi mathvariant='normal'>&micro;m</mi>
+          <mi mathvariant='normal'>&#xb5;m</mi>
         </math>
       MATHML
     end
@@ -277,7 +277,7 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       <<~MATHML
         <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-          &micro;
+          &#xb5;
         </math>
       MATHML
     end

--- a/spec/unitsml/conv/plurimath_spec.rb
+++ b/spec/unitsml/conv/plurimath_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       Plurimath::Math::Formula.new([
         Plurimath::Math::Function::FontStyle::Normal.new(
-          Plurimath::Math::Symbol.new("mm"),
+          Plurimath::Math::Symbols::Symbol.new("mm"),
           "normal"
         ),
-        Plurimath::Math::Symbol.new("&#x22c5;"),
+        Plurimath::Math::Symbols::Cdot.new,
         Plurimath::Math::Function::Power.new(
           Plurimath::Math::Function::FontStyle::Normal.new(
-            Plurimath::Math::Symbol.new("s"),
+            Plurimath::Math::Symbols::Symbol.new("s"),
             "normal"
           ),
           Plurimath::Math::Formula.new([
-            Plurimath::Math::Symbol.new("&#x2212;"),
+            Plurimath::Math::Symbols::Minus.new,
             Plurimath::Math::Number.new("2")
           ])
         )
@@ -34,7 +34,7 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       Plurimath::Math::Formula.new([
         Plurimath::Math::Function::FontStyle::SansSerif.new(
-          Plurimath::Math::Symbol.new("L"),
+          Plurimath::Math::Symbols::Symbol.new("L"),
           "sans-serif",
         )
       ])
@@ -49,7 +49,7 @@ RSpec.describe Unitsml::Parser do
     let(:exp) { "unitsml(k-)" }
     let(:expected_value) do
       Plurimath::Math::Formula.new([
-        Plurimath::Math::Symbol.new("k"),
+        Plurimath::Math::Symbols::Symbol.new("k"),
       ])
     end
 
@@ -63,7 +63,23 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       Plurimath::Math::Formula.new([
         Plurimath::Math::Function::FontStyle::Normal.new(
-          Plurimath::Math::Symbol.new("g"),
+          Plurimath::Math::Symbols::Symbol.new("g"),
+          "normal",
+        )
+      ])
+    end
+
+    it "compares expected value with to_plurimath method output" do
+      expect(formula).to eq(expected_value)
+    end
+  end
+
+  context "Unitsml example contains 'um' crashing while LutaML-Model integration in Plurimath" do
+    let(:exp) { "unitsml(um)" }
+    let(:expected_value) do
+      Plurimath::Math::Formula.new([
+        Plurimath::Math::Function::FontStyle::Normal.new(
+          Plurimath::Math::Symbols::Symbol.new("&#xb5;m"),
           "normal",
         )
       ])

--- a/unitsml.gemspec
+++ b/unitsml.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib", "unitsdb/**/*.yaml"]
 
-  spec.add_dependency "plurimath"
   spec.add_dependency "htmlentities"
+  spec.add_dependency "plurimath", "~> 0.8.4"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "equivalent-xml"
   spec.add_development_dependency "pry", "~> 0.12.2"


### PR DESCRIPTION
This PR changes **HTML** entities in **MathML** conversion to **Unicode** chars for Nokogiri compatibility while integrating **LutaML-Model** in **Plurimath**.
Additionally, I updated **Plurimath** symbols classes to the latest syntax in `plurimath_spec.rb`.

referenced -> plurimath/plurimath#304