### PR TITLE
Correct MathML for prefix only input

### DIFF
--- a/lib/unitsml/parser.rb
+++ b/lib/unitsml/parser.rb
@@ -23,6 +23,7 @@ module Unitsml
         norm_text: text,
       )
       update_units_exponents(formula.value, false)
+      formula.value.first.only_instance = true if text.end_with?("-")
       formula
     end
 

--- a/lib/unitsml/prefix.rb
+++ b/lib/unitsml/prefix.rb
@@ -2,15 +2,17 @@
 
 module Unitsml
   class Prefix
-    attr_accessor :prefix_name
+    attr_accessor :prefix_name, :only_instance
 
-    def initialize(prefix_name)
+    def initialize(prefix_name, only_instance = false)
       @prefix_name = prefix_name
+      @only_instance = only_instance
     end
 
     def ==(object)
       self.class == object.class &&
-        prefix_name == object&.prefix_name
+        prefix_name == object&.prefix_name &&
+        only_instance == object&.only_instance
     end
 
     def id
@@ -30,11 +32,14 @@ module Unitsml
     end
 
     def to_mathml
-      Utility.string_to_html_entity(
+      symbol = Utility.string_to_html_entity(
         Utility.html_entity_to_unicode(
           prefixes_symbols["html"]
         ),
       )
+      return symbol unless only_instance
+
+      Utility.ox_element("mi") << symbol
     end
 
     def to_latex

--- a/spec/unitsml/conv/mathml_spec.rb
+++ b/spec/unitsml/conv/mathml_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       <<~MATHML
         <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-          p
+          <mi>p</mi>
         </math>
       MATHML
     end
@@ -247,7 +247,7 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       <<~MATHML
         <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-          h
+          <mi>h</mi>
         </math>
       MATHML
     end
@@ -262,7 +262,7 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       <<~MATHML
         <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-          da
+          <mi>da</mi>
         </math>
       MATHML
     end
@@ -277,7 +277,7 @@ RSpec.describe Unitsml::Parser do
     let(:expected_value) do
       <<~MATHML
         <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-          &#xb5;
+          <mi>&#xb5;</mi>
         </math>
       MATHML
     end

--- a/spec/unitsml/conv/mathml_spec.rb
+++ b/spec/unitsml/conv/mathml_spec.rb
@@ -527,4 +527,19 @@ RSpec.describe Unitsml::Parser do
       expect(formula).to be_equivalent_to(expected_value)
     end
   end
+
+  context "contains Unitsml #27 example" do
+    let(:exp) { "unitsml(R-)" }
+
+    let(:expected_value) do
+      <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+          <mi>R</mi>
+        </math>
+      MATHML
+    end
+    it "returns parslet tree of parsed Unitsml string" do
+      expect(formula).to be_equivalent_to(expected_value)
+    end
+  end
 end

--- a/spec/unitsml/parser_spec.rb
+++ b/spec/unitsml/parser_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Prefix.new("p")
+          Unitsml::Prefix.new("p", true)
         ],
         norm_text: "p-",
         orig_text: "p-",
@@ -351,7 +351,7 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Prefix.new("h")
+          Unitsml::Prefix.new("h", true)
         ],
         norm_text: "h-",
         orig_text: "h-",
@@ -366,7 +366,7 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Prefix.new("da")
+          Unitsml::Prefix.new("da", true)
         ],
         norm_text: "da-",
         orig_text: "da-",
@@ -381,7 +381,7 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Prefix.new("u")
+          Unitsml::Prefix.new("u", true)
         ],
         norm_text: "u-",
         orig_text: "u-",


### PR DESCRIPTION
This PR fixes MathML output for prefix-only input following syntax `<prefix-key>-`.
Additionally, This PR updates the submodules from the latest commit of the main branch.

closes plurimath/asciimath2unitsml#39