### PR TITLE
Fix for failing example of watt per square meter

### DIFF
--- a/lib/unitsml/parser.rb
+++ b/lib/unitsml/parser.rb
@@ -8,6 +8,7 @@ module Unitsml
       @regexp = %r{(quantity|name|symbol|multiplier):\s*}
       @text = text&.match(/unitsml\((.*)\)/) ? Regexp.last_match[1] : text
       @orig_text = @text
+      @text = @text.gsub("−", "-")
       post_extras
     end
 

--- a/spec/unitsml/parser_spec.rb
+++ b/spec/unitsml/parser_spec.rb
@@ -542,4 +542,23 @@ RSpec.describe Unitsml::Parser do
       expect(formula).to eq(expected_value)
     end
   end
+
+  context "contains Unitsml #32 example from metanorma/bipm-si-brochure#245" do
+    let(:exp) { "unitsml(W*m^(−2))" }
+
+    it "returns Unitsml::Formula of parsed Unitsml string" do
+      expected_value = Unitsml::Formula.new([
+          Unitsml::Formula.new([
+            Unitsml::Unit.new("W"),
+            Unitsml::Extender.new("*"),
+            Unitsml::Unit.new("m", "-2"),
+          ])
+        ],
+        norm_text: "W*m^(-2)",
+        orig_text: "W*m^(-2)",
+        root: true,
+      )
+      expect(formula).to eq(expected_value)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `gsub` to replace `'&#x2212;'` with `'-'` for parsing rules.

closes metanorma/bipm-si-brochure#245