### PR TITLE
Lutaml-Model integration for YAML and XML processing

### DIFF
--- a/.github/workflows/dependent-repos.json
+++ b/.github/workflows/dependent-repos.json
@@ -1,0 +1,5 @@
+{
+  "repo": [
+    "plurimath/plurimath"
+  ]
+}

--- a/.github/workflows/depenedent-gems.yml
+++ b/.github/workflows/depenedent-gems.yml
@@ -1,0 +1,16 @@
+name: dependent-gems-test
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ v* ]
+  pull_request:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [ release-passed ]
+
+jobs:
+  rake:
+    uses: metanorma/ci/.github/workflows/dependent-rake.yml@main
+    with:
+      command: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 gem "byebug"
 gem "equivalent-xml"
 gem "oga"
+gem "ox"
 gem "plurimath"
 gem "pry"
 gem "rake"

--- a/lib/unitsml.rb
+++ b/lib/unitsml.rb
@@ -1,3 +1,13 @@
+# frozen_string_literal: true
+
+module Unitsml
+  UNITSML_NS = "https://schema.unitsml.org/unitsml/1.0".freeze
+
+  def self.parse(string)
+    Unitsml::Parser.new(string).parse
+  end
+end
+
 require "unitsml/error"
 require "unitsml/sqrt"
 require "unitsml/unit"
@@ -10,9 +20,19 @@ require "unitsml/unitsdb"
 require "unitsml/extender"
 require "unitsml/dimension"
 require "unitsml/transform"
-
-module Unitsml
-  def self.parse(string)
-    Unitsml::Parser.new(string).parse
-  end
-end
+require "unitsml/unitsdb/units"
+require "unitsml/unitsdb/prefixes"
+require "unitsml/unitsdb/dimension"
+require "unitsml/unitsdb/dimensions"
+require "unitsml/unitsdb/quantities"
+require "unitsml/unitsdb/dimension_quantity"
+require "unitsdb/config"
+Unitsdb::Config.models = {
+  units: Unitsml::Unitsdb::Units,
+  prefixes: Unitsml::Unitsdb::Prefixes,
+  dimension: Unitsml::Unitsdb::Dimension,
+  dimensions: Unitsml::Unitsdb::Dimensions,
+  quantities: Unitsml::Unitsdb::Quantities,
+  dimension_quantity: Unitsml::Unitsdb::DimensionQuantity,
+}
+require "unitsdb"

--- a/lib/unitsml/extender.rb
+++ b/lib/unitsml/extender.rb
@@ -14,7 +14,10 @@ module Unitsml
     end
 
     def to_mathml
-      Utility.ox_element("mo") << "&#x22c5;"
+      {
+        method_name: :mo,
+        value: ::Mml::Mo.new(value: "&#x22c5;"),
+      }
     end
 
     def to_latex

--- a/lib/unitsml/model/dimension.rb
+++ b/lib/unitsml/model/dimension.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "unitsml/model/dimension_quantities/quantity"
+require "unitsml/model/dimension_quantities/length"
+require "unitsml/model/dimension_quantities/mass"
+require "unitsml/model/dimension_quantities/time"
+require "unitsml/model/dimension_quantities/electric_current"
+require "unitsml/model/dimension_quantities/thermodynamic_temperature"
+require "unitsml/model/dimension_quantities/amount_of_substance"
+require "unitsml/model/dimension_quantities/luminous_intensity"
+require "unitsml/model/dimension_quantities/plane_angle"
+
+module Unitsml
+  module Model
+    class Dimension < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :length, DimensionQuantities::Length
+      attribute :mass, DimensionQuantities::Mass
+      attribute :time, DimensionQuantities::Time
+      attribute :electric_current, DimensionQuantities::ElectricCurrent
+      attribute :thermodynamic_temperature, DimensionQuantities::ThermodynamicTemperature
+      attribute :amount_of_substance, DimensionQuantities::AmountOfSubstance
+      attribute :luminous_intensity, DimensionQuantities::LuminousIntensity
+      attribute :plane_angle, DimensionQuantities::PlaneAngle
+
+      xml do
+        root "Dimension"
+        namespace Unitsml::UNITSML_NS
+
+        map_attribute :id, to: :id, namespace: nil, prefix: "xml"
+        map_element :Length, to: :length
+        map_element :Mass, to: :mass
+        map_element :Time, to: :time
+        map_element :ElectricCurrent, to: :electric_current
+        map_element :ThermodynamicTemperature, to: :thermodynamic_temperature
+        map_element :AmountOfSubstance, to: :amount_of_substance
+        map_element :LuminousIntensity, to: :luminous_intensity
+        map_element :PlaneAngle, to: :plane_angle
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/amount_of_substance.rb
+++ b/lib/unitsml/model/dimension_quantities/amount_of_substance.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class AmountOfSubstance < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/electric_current.rb
+++ b/lib/unitsml/model/dimension_quantities/electric_current.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class ElectricCurrent < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/length.rb
+++ b/lib/unitsml/model/dimension_quantities/length.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class Length < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/luminous_intensity.rb
+++ b/lib/unitsml/model/dimension_quantities/luminous_intensity.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class LuminousIntensity < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/mass.rb
+++ b/lib/unitsml/model/dimension_quantities/mass.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class Mass < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/plane_angle.rb
+++ b/lib/unitsml/model/dimension_quantities/plane_angle.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class PlaneAngle < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/quantity.rb
+++ b/lib/unitsml/model/dimension_quantities/quantity.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class Quantity < Lutaml::Model::Serializable
+        attribute :symbol, :string
+        attribute :power_numerator, :string
+
+        xml do
+          map_attribute :symbol, to: :symbol
+          map_attribute :powerNumerator, to: :power_numerator
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/thermodynamic_temperature.rb
+++ b/lib/unitsml/model/dimension_quantities/thermodynamic_temperature.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class ThermodynamicTemperature < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/dimension_quantities/time.rb
+++ b/lib/unitsml/model/dimension_quantities/time.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module DimensionQuantities
+      class Time < Quantity
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/prefix.rb
+++ b/lib/unitsml/model/prefix.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "unitsml/model/prefixes/name"
+require "unitsml/model/prefixes/symbol"
+
+
+module Unitsml
+  module Model
+    class Prefix < Lutaml::Model::Serializable
+      attribute :name, Prefixes::Name
+      attribute :id, :string
+      attribute :symbol, Prefixes::Symbol, collection: true
+      attribute :prefix_base, :string
+      attribute :prefix_power, :string
+
+      xml do
+        root "Prefix"
+        namespace Unitsml::UNITSML_NS
+
+        map_attribute :prefixBase, to: :prefix_base
+        map_attribute :prefixPower, to: :prefix_power
+        map_attribute :id, to: :id, namespace: nil, prefix: "xml"
+        map_element :PrefixName, to: :name
+        map_element :PrefixSymbol, to: :symbol
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/prefixes/name.rb
+++ b/lib/unitsml/model/prefixes/name.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    class Prefixes
+      class Name < Lutaml::Model::Serializable
+        attribute :lang, :string, default: -> { "en" }
+        attribute :content, :string
+
+        xml do
+          root "PrefixName"
+
+          map_attribute :lang, to: :lang, namespace: nil, prefix: "xml", render_default: true
+          map_content to: :content
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/prefixes/symbol.rb
+++ b/lib/unitsml/model/prefixes/symbol.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    class Prefixes
+      class Symbol < Lutaml::Model::Serializable
+        attribute :type, :string
+        attribute :content, :string
+
+        xml do
+          root "PrefixSymbol"
+
+          map_attribute :type, to: :type
+          map_content to: :content
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/quantities/name.rb
+++ b/lib/unitsml/model/quantities/name.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module Quantities
+      class Name < Lutaml::Model::Serializable
+        attribute :lang, :string, default: -> { "en-US" }
+        attribute :content, :string
+
+        xml do
+          root "QuantityName"
+
+          map_attribute :lang, to: :lang, namespace: nil, prefix: "xml", render_default: true
+          map_content to: :content
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/quantity.rb
+++ b/lib/unitsml/model/quantity.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "unitsml/model/quantities/name"
+
+module Unitsml
+  module Model
+    class Quantity < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :name, Quantities::Name, collection: true
+      attribute :quantity_type, :string, default: -> { "base" }
+      attribute :dimension_url, :string
+
+      xml do
+        root "Quantity"
+        namespace Unitsml::UNITSML_NS
+
+        map_attribute :id, to: :id, namespace: nil, prefix: "xml"
+        map_attribute :quantityType, to: :quantity_type, render_default: true
+        map_attribute :dimensionURL, to: :dimension_url
+        map_element :QuantityName, to: :name
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/unit.rb
+++ b/lib/unitsml/model/unit.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "unitsml/model/units/name"
+require "unitsml/model/units/symbol"
+require "unitsml/model/units/system"
+require "unitsml/model/units/root_units"
+
+module Unitsml
+  module Model
+    class Unit < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :name, Units::Name
+      attribute :dimension_url, :string
+      attribute :symbol, Units::Symbol, collection: true
+      attribute :system, Units::System, collection: true
+      attribute :root_units, Units::RootUnits
+
+      xml do
+        root "Unit"
+        namespace Unitsml::UNITSML_NS
+
+        map_attribute :dimensionURL, to: :dimension_url
+        map_attribute :id, to: :id, namespace: nil, prefix: "xml"
+        map_element :UnitName, to: :name
+        map_element :UnitSymbol, to: :symbol
+        map_element :UnitSystem, to: :system
+        map_element :RootUnits, to: :root_units
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/units/enumerated_root_unit.rb
+++ b/lib/unitsml/model/units/enumerated_root_unit.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module Units
+      class EnumeratedRootUnit < Lutaml::Model::Serializable
+        attribute :unit, :string
+        attribute :prefix, :string
+        attribute :power_numerator, :string
+
+        xml do
+          map_attribute :unit, to: :unit
+          map_attribute :prefix, to: :prefix
+          map_attribute :powerNumerator, to: :power_numerator
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/units/name.rb
+++ b/lib/unitsml/model/units/name.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module Units
+      class Name < Lutaml::Model::Serializable
+        attribute :name, :string
+        attribute :lang, :string, default: -> { "en" }
+
+        xml do
+          root "UnitName"
+
+          map_content to: :name
+          map_attribute :lang, to: :lang, namespace: nil, prefix: "xml", render_default: true
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/units/root_units.rb
+++ b/lib/unitsml/model/units/root_units.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "unitsml/model/units/enumerated_root_unit"
+
+module Unitsml
+  module Model
+    module Units
+      class RootUnits < Lutaml::Model::Serializable
+        attribute :enumerated_root_unit, EnumeratedRootUnit, collection: true
+
+        xml do
+          map_element :EnumeratedRootUnit, to: :enumerated_root_unit
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/units/symbol.rb
+++ b/lib/unitsml/model/units/symbol.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module Units
+      class Symbol < Lutaml::Model::Serializable
+        attribute :type, :string
+        attribute :content, :string
+
+        xml do
+          root "UnitSymbol"
+
+          map_attribute :type, to: :type
+          map_content to: :content, with: { from: :content_from_xml, to: :content_to_xml }
+        end
+
+        # Not reading any XML for now.
+        def content_from_xml(**); end
+
+        def content_to_xml(model, parent, doc)
+          doc.add_xml_fragment(parent, model.content)
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/model/units/system.rb
+++ b/lib/unitsml/model/units/system.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Model
+    module Units
+      class System < Lutaml::Model::Serializable
+        attribute :name, :string
+        attribute :type, :string
+        attribute :lang, :string, default: -> { "en-US" }
+
+        xml do
+          root "UnitSystem"
+
+          map_attribute :name, to: :name
+          map_attribute :type, to: :type
+          map_attribute :lang, to: :lang, namespace: nil, prefix: "xml", render_default: true
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/parse.rb
+++ b/lib/unitsml/parse.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 require "parslet"
-require_relative "unitsdb"
+require "unitsml/unitsdb"
 module Unitsml
   class Parse < Parslet::Parser
-    include Unitsml::Unitsdb
-
     rule(:power)    { str("^") >> intermediate_exp(number) }
     rule(:hyphen)   { str("-") }
     rule(:number)   { (hyphen.maybe >> match(/[0-9]/).repeat(1)).as(:integer) }
@@ -14,19 +12,19 @@ module Unitsml
     rule(:unit_and_power) { units >> power.maybe }
 
     rule(:units) do
-      @@filtered_units ||= arr_to_expression(Unitsdb.filtered_units, "units")
+      @@filtered_units ||= arr_to_expression(Unitsdb.units.filtered, "units")
     end
 
     rule(:single_letter_prefixes) do
-      @@prefixes1 ||= arr_to_expression(Unitsdb.prefixes.select { |p| p.size == 1 }, "prefixes")
+      @@prefixes1 ||= arr_to_expression(Unitsdb.prefixes_by_size(1), "prefixes")
     end
 
     rule(:double_letter_prefixes) do
-      @@prefixes2 ||= arr_to_expression(Unitsdb.prefixes.select { |p| p.size == 2 }, "prefixes")
+      @@prefixes2 ||= arr_to_expression(Unitsdb.prefixes_by_size(2), "prefixes")
     end
 
     rule(:dimensions) do
-      @@dimensions ||= arr_to_expression(Unitsdb.parsable_dimensions.keys, "dimensions")
+      @@dimensions ||= arr_to_expression(Unitsdb.dimensions.parsables.keys, "dimensions")
     end
 
     rule(:prefixes_units) do

--- a/lib/unitsml/parser.rb
+++ b/lib/unitsml/parser.rb
@@ -14,10 +14,10 @@ module Unitsml
 
     def parse
       nodes = Parse.new.parse(text)
+      transformed = Transform.new.apply(nodes)
+      formula_value = transformed.is_a?(Formula) ? transformed.value : Array(transformed)
       formula = Formula.new(
-        [
-          Transform.new.apply(nodes),
-        ],
+        formula_value,
         explicit_value: @extras_hash,
         root: true,
         orig_text: @orig_text,

--- a/lib/unitsml/prefix.rb
+++ b/lib/unitsml/prefix.rb
@@ -15,59 +15,59 @@ module Unitsml
         only_instance == object&.only_instance
     end
 
+    def prefix_instance
+      @prefix ||= Unitsdb.prefixes.find_by_symbol_name(prefix_name)
+    end
+
     def id
-      Unitsdb.prefixes_hash.dig(prefix_name, :id)
+      @prefix.id
     end
 
     def name
-      fields.dig("name")
-    end
-
-    def fields
-      Unitsdb.prefixes_hash.dig(prefix_name, :fields)
+      prefix_instance.name
     end
 
     def prefixes_symbols
-      fields&.dig("symbol")
+      prefix_instance.symbol
     end
 
     def to_mathml
       symbol = Utility.string_to_html_entity(
         Utility.html_entity_to_unicode(
-          prefixes_symbols["html"]
+          prefixes_symbols.html
         ),
       )
       return symbol unless only_instance
 
-      Utility.ox_element("mi") << symbol
+      { method_name: :mi, value: ::Mml::Mi.new(value: symbol)}
     end
 
     def to_latex
-      prefixes_symbols["latex"]
+      prefixes_symbols.latex
     end
 
     def to_asciimath
-      prefixes_symbols["ascii"]
+      prefixes_symbols.ascii
     end
 
     def to_html
-      prefixes_symbols["html"]
+      prefixes_symbols.html
     end
 
     def to_unicode
-      prefixes_symbols["unicode"]
+      prefixes_symbols.unicode
     end
 
     def symbolid
-      prefixes_symbols["ascii"] if prefixes_symbols
+      prefixes_symbols.ascii if prefixes_symbols
     end
 
     def base
-      fields&.dig("base")
+      prefix_instance.base
     end
 
     def power
-      fields&.dig("power")
+      prefix_instance.power
     end
   end
 end

--- a/lib/unitsml/unitsdb.rb
+++ b/lib/unitsml/unitsdb.rb
@@ -1,96 +1,38 @@
 # frozen_string_literal: true
 
-require "yaml"
 module Unitsml
   module Unitsdb
     class << self
-      def load_yaml(file_name)
+      def load_file(file_name)
         @@hash ||= {}
-        @@hash[file_name] ||= YAML.load_file(valid_path(file_name))
-      end
-
-      def load_dimensions
-        @@dim_file = load_yaml(:dimensions)
-      end
-
-      def load_units
-        @@units_file = load_yaml(:units)
+        @@hash[file_name] ||= File.read(valid_path(file_name))
       end
 
       def units
-        @@units ||= {}
-        return @@units unless @@units.empty?
-
-        load_units.each do |key, value|
-          value["unit_symbols"]&.each do |symbol|
-            @@units[symbol["id"]] = { id: key, fields: value } unless symbol["id"]&.empty?
-          end
-        end
-        @@units
+        @@units_file ||= ::Unitsdb::Units.from_yaml(load_file((:units)))
       end
 
       def prefixes
-        @@prefixes_array ||= prefixes_hash.keys.sort_by(&:length)
+        @@prefixes ||= ::Unitsdb::Prefixes.from_yaml(load_file(:prefixes))
       end
 
-      def parsable_dimensions
-        @@parsable_dimensions ||= {}
-        return @@parsable_dimensions unless @@parsable_dimensions.empty?
-
-        dimensions_hash.each do |key, value|
-          value.each do |_, v|
-            @@parsable_dimensions[find_id(v)] = { id: key, fields: value }
-          end
-        end
-        @@parsable_dimensions
+      def dimensions
+        @@dim_file ||= ::Unitsdb::Dimensions.from_yaml(load_file(:dimensions))
       end
 
       def quantities
-        @@quantities ||= load_yaml(:quantities)
+        @@quantities ||= ::Unitsdb::Quantities.from_yaml(load_file((:quantities)))
       end
 
-      def filtered_units
-        @@filtered_units_array ||= units.keys.reject do |unit|
-          ((/\*|\^|\/|^1$/).match?(unit) || units.dig(unit, :fields, "prefixed"))
-        end
+      def prefixes_array
+        @@prefixes_array ||= prefixes.ascii_symbols.sort_by(&:length)
       end
 
-      def prefixes_hash
-        @@prefixes_hashes ||= prefixs_ids(load_yaml(:prefixes))
-      end
+      def prefixes_by_size(size)
+        @@sized_prefixes ||= {}
+        return @@sized_prefixes[size] if @@sized_prefixes.key?(size)
 
-      def dimensions_hash
-        @@dimensions_hashs ||= insert_vectors(load_dimensions)
-      end
-
-      def prefixs_ids(prefixe_hash, hash = {})
-        prefixe_hash&.each do |key, value|
-          symbol = value&.dig("symbol", "ascii")
-          hash[symbol] = { id: key, fields: value } unless symbol&.empty?
-        end
-        hash
-      end
-
-      def find_id(value)
-        return if value == true
-        return unless value.is_a?(Hash)
-
-        value&.dig("dim_symbols")&.map { |symbol| symbol&.dig("id") }&.first
-      end
-
-      def vector(dim_hash)
-        Utility::DIMS_VECTOR.map { |h| dim_hash.dig(underscore(h), "powerNumerator") }.join(":")
-      end
-
-      def underscore(str)
-        str.gsub(/([a-z])([A-Z])/, '\1_\2').downcase
-      end
-
-      def insert_vectors(dims)
-        dims.each do |key, value|
-          value[:vector] = vector(value)
-          value[:id] = key
-        end
+        @@sized_prefixes[size] = prefixes_array.select { |p| p.size == size }
       end
 
       def valid_path(file_name)

--- a/lib/unitsml/unitsdb/dimension.rb
+++ b/lib/unitsml/unitsdb/dimension.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Unitsdb
+    class Dimension
+      attr_accessor :vector,
+                    :id,
+                    :dimensionless
+
+      attr_reader :length,
+                  :mass,
+                  :time,
+                  :electric_current,
+                  :thermodynamic_temperature,
+                  :amount_of_substance,
+                  :luminous_intensity,
+                  :plane_angle,
+                  :parsables,
+                  :parsable,
+                  :processed_keys
+
+      def initialize
+        @parsables = {}
+        @processed_keys = []
+        @parsable = false
+      end
+
+      def length=(value)
+        quantities_common_code(:length, value)
+      end
+
+      def mass=(value)
+        quantities_common_code(:mass, value)
+      end
+
+      def time=(value)
+        quantities_common_code(:time, value)
+      end
+
+      def thermodynamic_temperature=(value)
+        quantities_common_code(:thermodynamic_temperature, value)
+      end
+
+      def amount_of_substance=(value)
+        quantities_common_code(:amount_of_substance, value)
+      end
+
+      def luminous_intensity=(value)
+        quantities_common_code(:luminous_intensity, value)
+      end
+
+      def plane_angle=(value)
+        quantities_common_code(:plane_angle, value)
+      end
+
+      def electric_current=(value)
+        quantities_common_code(:electric_current, value)
+      end
+
+      def dim_symbols
+        processed_keys.map { |vec| public_send(vec)&.dim_symbols&.map(&:id) }.flatten.compact
+      end
+
+      def processed_symbol
+        public_send(processed_keys.first).symbol
+      end
+
+      def set_vector
+        @vector ||= Utility::DIMS_VECTOR.map do |h|
+          public_send(Utility.underscore(h))&.power_numerator
+        end.join(":")
+      end
+
+      private
+
+      def quantities_common_code(instance_var, value)
+        return if value.nil?
+
+        instance_variable_set(:"@#{instance_var}", value)
+        @processed_keys << instance_var.to_s
+        return if value.dim_symbols.empty?
+
+        @parsable = true
+        value.dim_symbols_ids(@parsables, id)
+      end
+    end
+  end
+end

--- a/lib/unitsml/unitsdb/dimension_quantity.rb
+++ b/lib/unitsml/unitsdb/dimension_quantity.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Unitsdb
+    class DimensionQuantity
+      attr_accessor :power_numerator,
+                    :symbol,
+                    :dim_symbols
+
+      def dim_symbols_ids(hash, dim_id)
+        dim_symbols.each { |dim_sym| hash[dim_sym.id] = dim_id }
+      end
+    end
+  end
+end

--- a/lib/unitsml/unitsdb/dimensions.rb
+++ b/lib/unitsml/unitsdb/dimensions.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Unitsdb
+    class Dimensions
+      attr_accessor :dimensions
+
+      def find_by_vector(vector)
+        vectored
+        find(:vector, vector)
+      end
+
+      def find_by_id(d_id)
+        find(:id, d_id)
+      end
+
+      def find_parsables_by_id(d_id)
+        find(:id, parsables[d_id])
+      end
+
+      def parsables
+        @parsables ||= dimensions.select(&:parsables).each_with_object({}) do |dimension, object|
+          object.merge!(dimension.parsables)
+        end
+      end
+
+      private
+
+      def vectored
+        @vectored ||= dimensions.each(&:set_vector)
+      end
+
+      def find(field, matching_data)
+        dimensions.find { |dim| dim.send(field) == matching_data }
+      end
+    end
+  end
+end

--- a/lib/unitsml/unitsdb/prefixes.rb
+++ b/lib/unitsml/unitsdb/prefixes.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Unitsdb
+    class Prefixes
+      attr_accessor :prefixes
+
+      def find_by_symbol_name(ascii_sym)
+        prefixes.find { |prefix| prefix.symbol.ascii == ascii_sym }
+      end
+
+      def ascii_symbols
+        prefixes.each_with_object([]) do |prefix, names_array|
+          symbol = prefix.symbol.ascii
+          next if symbol.empty?
+
+          names_array << symbol
+        end
+      end
+    end
+  end
+end

--- a/lib/unitsml/unitsdb/quantities.rb
+++ b/lib/unitsml/unitsdb/quantities.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Unitsdb
+    class Quantities
+      attr_accessor :quantities
+
+      def find_by_id(q_id)
+        quantities.find { |quantity| quantity.id == q_id }
+      end
+    end
+  end
+end

--- a/lib/unitsml/unitsdb/units.rb
+++ b/lib/unitsml/unitsdb/units.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Unitsml
+  module Unitsdb
+    class Units
+      attr_accessor :units
+
+      def find_by_id(u_id)
+        units.find { |unit| unit.id == u_id }
+      end
+
+      def find_by_name(u_name)
+        units.find do |unit|
+          unit.unit_symbols.find { |u_sym| u_sym.id == u_name }
+        end
+      end
+
+      def filtered
+        @filtered ||= units_symbol_ids.reject do |unit|
+          ((/\*|\^|\/|^1$/).match?(unit) || find_by_symbol_id(unit).prefixed)
+        end
+      end
+
+      def find_by_symbol_id(sym_id)
+        units_symbol_hash[sym_id]
+      end
+
+      def units_symbol_ids
+        units_symbol_hash.keys
+      end
+
+      def units_symbol_hash
+        @symbol_ids_hash ||= {}
+
+        if @symbol_ids_hash.empty?
+          units.each_with_object(@symbol_ids_hash) do |unit, object|
+            unit.unit_symbols.each { |unit_sym| object[unit_sym.id] = unit }
+          end
+        end
+        @symbol_ids_hash
+      end
+    end
+  end
+end

--- a/spec/unitsml/conv/mathml_spec.rb
+++ b/spec/unitsml/conv/mathml_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 RSpec.describe Unitsml::Parser do
 
+  before(:all) { Lutaml::Model::Config.xml_adapter_type = :ox }
+
   subject(:formula) { described_class.new(exp).parse.to_mathml }
 
   context "contains Unitsml #1 example" do

--- a/spec/unitsml/conv/xml_spec.rb
+++ b/spec/unitsml/conv/xml_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 RSpec.describe Unitsml::Parser do
 
+  before(:all) { Lutaml::Model::Config.xml_adapter_type = :ox }
+
   subject(:formula) { described_class.new(exp).parse.to_xml }
 
   context "contains Unitsml #1 example" do

--- a/spec/unitsml/parser_spec.rb
+++ b/spec/unitsml/parser_spec.rb
@@ -9,14 +9,12 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
+          Unitsml::Unit.new("K"),
+          Unitsml::Extender.new("/"),
           Unitsml::Formula.new([
-            Unitsml::Unit.new("K"),
-            Unitsml::Extender.new("/"),
-            Unitsml::Formula.new([
-              Unitsml::Unit.new("g", "-1", prefix: Unitsml::Prefix.new("k")),
-              Unitsml::Extender.new("*"),
-              Unitsml::Unit.new("m", "-1"),
-            ])
+            Unitsml::Unit.new("g", "-1", prefix: Unitsml::Prefix.new("k")),
+            Unitsml::Extender.new("*"),
+            Unitsml::Unit.new("m", "-1"),
           ])
         ],
         explicit_value: nil,
@@ -51,11 +49,9 @@ RSpec.describe Unitsml::Parser do
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new(
         [
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("cal_th"),
-            Unitsml::Extender.new("/"),
-            Unitsml::Unit.new("m", "-2", prefix: Unitsml::Prefix.new("c")),
-          ])
+          Unitsml::Unit.new("cal_th"),
+          Unitsml::Extender.new("/"),
+          Unitsml::Unit.new("m", "-2", prefix: Unitsml::Prefix.new("c")),
         ],
         explicit_value: { name: "langley" },
         norm_text: "cal_th/cm^2",
@@ -89,11 +85,9 @@ RSpec.describe Unitsml::Parser do
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new(
         [
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("m", prefix: Unitsml::Prefix.new("c")),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("s", "-2")
-          ])
+          Unitsml::Unit.new("m", prefix: Unitsml::Prefix.new("c")),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("s", "-2")
         ],
         explicit_value: { symbol: "cm cdot s^-2"},
         root: true,
@@ -110,11 +104,9 @@ RSpec.describe Unitsml::Parser do
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new(
         [
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("m", prefix: Unitsml::Prefix.new("c")),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("s", "-2"),
-          ])
+          Unitsml::Unit.new("m", prefix: Unitsml::Prefix.new("c")),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("s", "-2"),
         ],
         explicit_value: { multiplier: "xx" },
         norm_text: "cm*s^-2",
@@ -131,11 +123,9 @@ RSpec.describe Unitsml::Parser do
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new(
         [
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("m", prefix: Unitsml::Prefix.new("m")),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("s", "-2"),
-          ]),
+          Unitsml::Unit.new("m", prefix: Unitsml::Prefix.new("m")),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("s", "-2"),
         ],
         root: true,
         orig_text: "mm*s^-2",
@@ -302,11 +292,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("g", prefix: Unitsml::Prefix.new("k")),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("s", "-2")
-          ])
+          Unitsml::Unit.new("g", prefix: Unitsml::Prefix.new("k")),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("s", "-2")
         ],
         norm_text: "kg*s^-2",
         orig_text: "kg*s^-2",
@@ -396,11 +384,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("A"),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("C", "3"),
-          ])
+          Unitsml::Unit.new("A"),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("C", "3"),
         ],
         norm_text: "A*C^3",
         orig_text: "A*C^3",
@@ -415,11 +401,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("A"),
-            Unitsml::Extender.new("/"),
-            Unitsml::Unit.new("C", "3"),
-          ])
+          Unitsml::Unit.new("A"),
+          Unitsml::Extender.new("/"),
+          Unitsml::Unit.new("C", "3"),
         ],
         norm_text: "A/C^-3",
         orig_text: "A/C^-3",
@@ -434,14 +418,12 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
+          Unitsml::Unit.new("J"),
+          Unitsml::Extender.new("/"),
           Unitsml::Formula.new([
-            Unitsml::Unit.new("J"),
-            Unitsml::Extender.new("/"),
-            Unitsml::Formula.new([
-              Unitsml::Unit.new("g", "-1", prefix: Unitsml::Prefix.new("k")),
-              Unitsml::Extender.new("*"),
-              Unitsml::Unit.new("K", "-1"),
-            ])
+            Unitsml::Unit.new("g", "-1", prefix: Unitsml::Prefix.new("k")),
+            Unitsml::Extender.new("*"),
+            Unitsml::Unit.new("K", "-1"),
           ])
         ],
         norm_text: "J/kg*K",
@@ -472,11 +454,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("W", prefix: Unitsml::Prefix.new("m")),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("m", "-2", prefix: Unitsml::Prefix.new("c")),
-          ])
+          Unitsml::Unit.new("W", prefix: Unitsml::Prefix.new("m")),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("m", "-2", prefix: Unitsml::Prefix.new("c")),
         ],
         norm_text: "mW*cm(-2)",
         orig_text: "mW*cm(-2)",
@@ -491,11 +471,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Dimension.new("dim_Theta"),
-            Unitsml::Extender.new("*"),
-            Unitsml::Dimension.new("dim_L", "2"),
-          ])
+          Unitsml::Dimension.new("dim_Theta"),
+          Unitsml::Extender.new("*"),
+          Unitsml::Dimension.new("dim_L", "2"),
         ],
         norm_text: "dim_Theta*dim_L^2",
         orig_text: "dim_Theta*dim_L^2",
@@ -510,11 +488,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Dimension.new("dim_Theta", "10"),
-            Unitsml::Extender.new("*"),
-            Unitsml::Dimension.new("dim_L", "2"),
-          ])
+          Unitsml::Dimension.new("dim_Theta", "10"),
+          Unitsml::Extender.new("*"),
+          Unitsml::Dimension.new("dim_L", "2"),
         ],
         norm_text: "dim_Theta^10*dim_L^2",
         orig_text: "dim_Theta^10*dim_L^2",
@@ -529,11 +505,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns parslet tree of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("Hz", "10"),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("darcy", "-100"),
-          ])
+          Unitsml::Unit.new("Hz", "10"),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("darcy", "-100"),
         ],
         norm_text: "Hz^10*darcy^-100",
         orig_text: "Hz^10*darcy^-100",
@@ -548,11 +522,9 @@ RSpec.describe Unitsml::Parser do
 
     it "returns Unitsml::Formula of parsed Unitsml string" do
       expected_value = Unitsml::Formula.new([
-          Unitsml::Formula.new([
-            Unitsml::Unit.new("W"),
-            Unitsml::Extender.new("*"),
-            Unitsml::Unit.new("m", "-2"),
-          ])
+          Unitsml::Unit.new("W"),
+          Unitsml::Extender.new("*"),
+          Unitsml::Unit.new("m", "-2"),
         ],
         norm_text: "W*m^(-2)",
         orig_text: "W*m^(-2)",

--- a/unitsml.gemspec
+++ b/unitsml.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib", "unitsdb/**/*.yaml"]
 
   spec.add_dependency "htmlentities"
-  spec.add_dependency "ox"
+  spec.add_dependency "mml"
   spec.add_dependency "parslet"
+  spec.add_dependency "unitsdb"
 end


### PR DESCRIPTION
This PR integrates **[Unitsdb-Ruby](https://github.com/unitsml/unitsdb-ruby)** for **Unitsdb** content processing.
Additionally, it supports processing of **XML** and **MathML** using **Lutaml-Model** classes.

closes #21 