### PR TITLE
`multiplier` argument support 

### DIFF
--- a/lib/unitsml/dimension.rb
+++ b/lib/unitsml/dimension.rb
@@ -23,7 +23,7 @@ module Unitsml
       dim_instance.send(@dim.processed_keys.last).dim_symbols.first
     end
 
-    def to_mathml
+    def to_mathml(_)
       # MathML key's value in unitsdb/dimensions.yaml file includes mi tags only.
       value = ::Mml::Mi.from_xml(dim_symbols.mathml)
       method_name = power_numerator ? :msup : :mi
@@ -40,19 +40,19 @@ module Unitsml
       { method_name: method_name, value: value }
     end
 
-    def to_latex
+    def to_latex(_)
       power_numerator_generic_code(:latex)
     end
 
-    def to_asciimath
+    def to_asciimath(_)
       power_numerator_generic_code(:ascii)
     end
 
-    def to_unicode
+    def to_unicode(_)
       power_numerator_generic_code(:unicode)
     end
 
-    def to_html
+    def to_html(_)
       value = dim_symbols.html
       value = "#{value}<sup>#{power_numerator}</sup>" if power_numerator
       value
@@ -62,7 +62,7 @@ module Unitsml
       "#{dimension_name.split('_').last}#{power_numerator}"
     end
 
-    def to_xml
+    def to_xml(_)
       attributes = {
         symbol: dim_instance.processed_symbol,
         power_numerator: power_numerator || 1,
@@ -70,8 +70,8 @@ module Unitsml
       Model::DimensionQuantities.const_get(modelize(element_name)).new(attributes)
     end
 
-    def xml_instances_hash
-      { element_name => to_xml }
+    def xml_instances_hash(options)
+      { element_name => to_xml(options) }
     end
 
     def modelize(value)

--- a/lib/unitsml/extender.rb
+++ b/lib/unitsml/extender.rb
@@ -13,27 +13,38 @@ module Unitsml
         symbol == object&.symbol
     end
 
-    def to_mathml
+    def to_mathml(options)
+      multiplier = case options[:multiplier]
+                   when :space
+                     rspace = "thickmathspace"
+                     "&#x2062;"
+                   when :nospace
+                     "&#x2062;"
+                   else
+                     extender = options[:multiplier] || "⋅"
+                     Utility.string_to_html_entity(extender)
+                   end
       {
         method_name: :mo,
-        value: ::Mml::Mo.new(value: "&#x22c5;"),
+        value: ::Mml::Mo.new(value: multiplier, rspace: rspace),
       }
     end
 
-    def to_latex
-      "/"
+    def to_latex(options)
+      options[:multiplier] || "/"
     end
 
-    def to_asciimath
-      symbol
+    def to_asciimath(options)
+      options[:multiplier] || symbol
     end
 
-    def to_html
-      "&#x22c5;"
+    def to_html(options)
+      options[:multiplier] || "&#x22c5;"
     end
 
-    def to_unicode
-      symbol == "*" ? "·" : symbol
+    def to_unicode(options)
+      options[:multiplier] ||
+        symbol == "*" ? "·" : symbol
     end
   end
 end

--- a/lib/unitsml/model/unit.rb
+++ b/lib/unitsml/model/unit.rb
@@ -21,9 +21,9 @@ module Unitsml
 
         map_attribute :dimensionURL, to: :dimension_url
         map_attribute :id, to: :id, namespace: nil, prefix: "xml"
+        map_element :UnitSystem, to: :system
         map_element :UnitName, to: :name
         map_element :UnitSymbol, to: :symbol
-        map_element :UnitSystem, to: :system
         map_element :RootUnits, to: :root_units
       end
     end

--- a/lib/unitsml/prefix.rb
+++ b/lib/unitsml/prefix.rb
@@ -31,7 +31,7 @@ module Unitsml
       prefix_instance.symbol
     end
 
-    def to_mathml
+    def to_mathml(_)
       symbol = Utility.string_to_html_entity(
         Utility.html_entity_to_unicode(
           prefixes_symbols.html
@@ -42,19 +42,19 @@ module Unitsml
       { method_name: :mi, value: ::Mml::Mi.new(value: symbol)}
     end
 
-    def to_latex
+    def to_latex(_)
       prefixes_symbols.latex
     end
 
-    def to_asciimath
+    def to_asciimath(_)
       prefixes_symbols.ascii
     end
 
-    def to_html
+    def to_html(_)
       prefixes_symbols.html
     end
 
-    def to_unicode
+    def to_unicode(_)
       prefixes_symbols.unicode
     end
 

--- a/lib/unitsml/sqrt.rb
+++ b/lib/unitsml/sqrt.rb
@@ -13,24 +13,24 @@ module Unitsml
         value == object&.value
     end
 
-    def to_asciimath
-      value&.to_asciimath
+    def to_asciimath(options)
+      value&.to_asciimath(options)
     end
 
-    def to_latex
-      value&.to_latex
+    def to_latex(options)
+      value&.to_latex(options)
     end
 
-    def to_mathml
-      value&.to_mathml
+    def to_mathml(options)
+      value&.to_mathml(options)
     end
 
-    def to_html
-      value&.to_html
+    def to_html(options)
+      value&.to_html(options)
     end
 
-    def to_unicode
-      value.to_unicode
+    def to_unicode(options)
+      value&.to_unicode(options)
     end
   end
 end

--- a/lib/unitsml/unit.rb
+++ b/lib/unitsml/unit.rb
@@ -41,11 +41,11 @@ module Unitsml
       { mo_value: [mo_tag], mn_value: [integer] }
     end
 
-    def to_mathml
+    def to_mathml(options)
       value = unit_symbols&.mathml
       tag_name = value.match(/^<(?<tag>\w+)/)[:tag]
       value = ::Mml.const_get(tag_name.capitalize).from_xml(value)
-      value.value = "#{prefix.to_mathml}#{value.value}" if prefix
+      value.value = "#{prefix.to_mathml(options)}#{value.value}" if prefix
       if power_numerator
         value = ::Mml::Msup.new(
           mrow_value: [
@@ -58,33 +58,33 @@ module Unitsml
       { method_name: tag_name.to_sym, value: value }
     end
 
-    def to_latex
+    def to_latex(options)
       value = unit_symbols&.latex
       value = "#{value}^#{power_numerator}" if power_numerator
-      value = "#{prefix.to_latex}#{value}" if prefix
+      value = "#{prefix.to_latex(options)}#{value}" if prefix
       value
     end
 
-    def to_asciimath
+    def to_asciimath(options)
       value = unit_symbols&.ascii
       value = "#{value}^#{power_numerator}" if power_numerator
-      value = "#{prefix.to_asciimath}#{value}" if prefix
+      value = "#{prefix.to_asciimath(options)}#{value}" if prefix
       value
     end
 
-    def to_html
+    def to_html(options)
       value = unit_symbols&.html
       if power_numerator
         value = "#{value}<sup>#{numerator_value(false)}</sup>"
       end
-      value = "#{prefix.to_html}#{value}" if prefix
+      value = "#{prefix.to_html(options)}#{value}" if prefix
       value
     end
 
-    def to_unicode
+    def to_unicode(options)
       value = unit_symbols&.unicode
       value = "#{value}^#{power_numerator}" if power_numerator
-      value = "#{prefix.to_unicode}#{value}" if prefix
+      value = "#{prefix.to_unicode(options)}#{value}" if prefix
       value
     end
 

--- a/lib/unitsml/utility.rb
+++ b/lib/unitsml/utility.rb
@@ -142,12 +142,12 @@ module Unitsml
         "unknown"
       end
 
-      def unit(units, formula, dims, norm_text, name)
+      def unit(units, formula, dims, norm_text, name, options)
         attributes = {
           id: unit_id(norm_text),
           system: unitsystem(units),
           name: unitname(units, norm_text, name),
-          symbol: unitsymbols(formula),
+          symbol: unitsymbols(formula, options),
           root_units: rootunits(units),
         }
         attributes[:dimension_url] = "##{dim_id(dims)}" if dims
@@ -173,9 +173,9 @@ module Unitsml
         unit.power_numerator && unit.power_numerator != "1" ? "^#{unit.power_numerator}" : ""
       end
 
-      def unitsymbols(formula)
+      def unitsymbols(formula, options)
         %w[HTML MathMl].map do |lang|
-          Model::Units::Symbol.new(type: lang, content: formula.public_send(:"to_#{lang.downcase}"))
+          Model::Units::Symbol.new(type: lang, content: formula.public_send(:"to_#{lang.downcase}", options))
         end
       end
 
@@ -232,7 +232,7 @@ module Unitsml
         end
       end
 
-      def prefixes(units)
+      def prefixes(units, options)
         uniq_prefixes = units.map { |unit| unit.prefix }.compact.uniq {|d| d.prefix_name }
         uniq_prefixes.map do |prefix|
           prefix_attrs = { prefix_base: prefix&.base, prefix_power: prefix&.power, id: prefix&.id }
@@ -241,7 +241,7 @@ module Unitsml
           prefix_attrs[:symbol] = type_and_methods.map do |type, method_name|
             Model::Prefixes::Symbol.new(
               type: type,
-              content: prefix&.public_send(method_name),
+              content: prefix&.public_send(method_name, options),
             )
           end
           Model::Prefix.new(prefix_attrs).to_xml.gsub("&amp;", "&")

--- a/spec/unitsml/conv/asciimath_spec.rb
+++ b/spec/unitsml/conv/asciimath_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "mm*s^-2" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -18,7 +18,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "um" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "degK" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "'" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "rad" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "Hz" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -63,7 +63,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "kg" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "m" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "Hz^0.5" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -90,7 +90,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "g" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "hp" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -108,7 +108,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "kg*s^-2" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -117,7 +117,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "mbar" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -126,7 +126,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "p" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -135,7 +135,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "h" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -144,7 +144,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "da" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -153,7 +153,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "u" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -162,7 +162,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "A*C^3" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -171,7 +171,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "A/C^3" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -180,7 +180,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "J/kg^-1*K^-1" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -189,7 +189,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "kg^-2" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -198,7 +198,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "kg*s^-2" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -207,7 +207,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "mW*cm^-2" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -216,7 +216,7 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "Theta*L^2" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
@@ -225,16 +225,16 @@ RSpec.describe Unitsml::Parser do
 
     let(:expected_value) { "Theta^10*L^2" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 
   context "contains Unitsml #26 example" do
-    let(:exp) { "unitsml(Hz^10*darcy^100)" }
+    let(:exp) { "unitsml(Hz^10*darcy^100, multiplier: xx)" }
 
-    let(:expected_value) { "Hz^10*d^100" }
+    let(:expected_value) { "Hz^10xxd^100" }
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(formula).to eq(expected_value)
     end
   end
 end

--- a/spec/unitsml/conv/mathml_spec.rb
+++ b/spec/unitsml/conv/mathml_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Unitsml::Parser do
 
   before(:all) { Lutaml::Model::Config.xml_adapter_type = :ox }
 
-  subject(:formula) { described_class.new(exp).parse.to_mathml }
+  subject(:formula) { described_class.new(exp).parse }
+  subject(:mathml) { formula.to_mathml }
 
   context "contains Unitsml #1 example" do
     let(:exp) { "unitsml(mm*s^-2)" }
@@ -27,7 +28,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -42,7 +43,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -57,7 +58,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -72,7 +73,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -87,7 +88,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -102,7 +103,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -117,7 +118,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -132,7 +133,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -154,7 +155,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -169,7 +170,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -184,7 +185,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -209,7 +210,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -224,7 +225,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -239,7 +240,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -254,7 +255,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -269,7 +270,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -284,7 +285,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -308,7 +309,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -332,7 +333,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -367,7 +368,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -390,7 +391,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -415,7 +416,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -440,7 +441,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -464,7 +465,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -495,7 +496,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -526,7 +527,7 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
     end
   end
 
@@ -541,7 +542,53 @@ RSpec.describe Unitsml::Parser do
       MATHML
     end
     it "returns parslet tree of parsed Unitsml string" do
-      expect(formula).to be_equivalent_to(expected_value)
+      expect(mathml).to be_equivalent_to(expected_value)
+    end
+  end
+
+  context "contains Unitsml #28 example" do
+    let(:exp) { "unitsml(Rm*A)" }
+
+    let(:expected_value) do
+      <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+          <mi mathvariant="normal">Rm</mi>
+          <mo>X</mo>
+          <mi mathvariant="normal">A</mi>
+        </math>
+      MATHML
+    end
+
+    let(:space_expected_value) do
+      <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+          <mi mathvariant="normal">Rm</mi>
+          <mo rspace="thickmathspace">&#x2062;</mo>
+          <mi mathvariant="normal">A</mi>
+        </math>
+      MATHML
+    end
+
+    let(:nospace_expected_value) do
+      <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+          <mi mathvariant="normal">Rm</mi>
+          <mo>&#x2062;</mo>
+          <mi mathvariant="normal">A</mi>
+        </math>
+      MATHML
+    end
+
+    it "matches Unitsml to MathML converted string with custom multiplier argument" do
+      expect(formula.to_mathml(multiplier: "X")).to be_equivalent_to(expected_value)
+    end
+
+    it "matches Unitsml to MathML converted string with :space multiplier argument" do
+      expect(formula.to_mathml(multiplier: :space)).to be_equivalent_to(space_expected_value)
+    end
+
+    it "matches Unitsml to MathML converted string with :nospace multiplier argument" do
+      expect(formula.to_mathml(multiplier: :nospace)).to be_equivalent_to(nospace_expected_value)
     end
   end
 end


### PR DESCRIPTION
This PR adds `multiplier` argument support in conversion methods (`to_<supported-language>`) and in the equation following `unitsml(<equation>, multiplier: <multiplier>)`.

related => plurimath/plurimath#342