### PR TITLE
removed ox encoding in Utility

### DIFF
--- a/lib/unitsml/utility.rb
+++ b/lib/unitsml/utility.rb
@@ -7,8 +7,6 @@ require "unitsml/model/dimension"
 
 module Unitsml
   module Utility
-    Ox.default_options = { encoding: "UTF-8" }
-
     # Unit to dimension
     U2D = {
       "m" => { dimension: "Length", order: 1, symbol: "L" },


### PR DESCRIPTION
This PR removes `Ox.default_options` since it's handled in **LutaML-Model** and causing issues in **Plurimath-JS**.

related => **plurimath/plurimath#289**