### PR TITLE
fix: lutaml-model instances creation for MathML

### DIFF
--- a/lib/unitsml/formula.rb
+++ b/lib/unitsml/formula.rb
@@ -33,15 +33,7 @@ module Unitsml
         math = ::Mml::MathWithNamespace.new(display: "block")
         math.ordered = true
         math.element_order ||= []
-        value.each do |instance|
-          processed_instance = instance.to_mathml(options)
-          case processed_instance
-          when Array
-            processed_instance.each { |hash| add_math_element(math, hash) }
-          when Hash
-            add_math_element(math, processed_instance)
-          end
-        end
+        value.each { |instance| process_value(math, instance.to_mathml(options)) }
         reset_mml_models if plurimath_available?
         math.to_xml.gsub(/&amp;(.*?)(?=<\/)/, '&\1')
       else
@@ -184,6 +176,15 @@ module Unitsml
 
     def reset_mml_models
       ::Mml::Configuration.custom_models = Plurimath::Mathml::Parser::CONFIGURATION
+    end
+
+    def process_value(math, mathml_instances)
+      case mathml_instances
+      when Array
+        mathml_instances.each { |hash| process_value(math, hash) }
+      when Hash
+        add_math_element(math, mathml_instances)
+      end
     end
 
     def update_options(options)

--- a/spec/unitsml/conv/plurimath_spec.rb
+++ b/spec/unitsml/conv/plurimath_spec.rb
@@ -101,4 +101,55 @@ RSpec.describe Unitsml::Parser do
       expect(formula).to eq(expected_value)
     end
   end
+
+  context "Unitsml example crashing in plurimath/plurimath#343" do
+    let(:exp) { "unitsml(kg^(-1)*m^(-3)*s^4*A^2)" }
+    let(:expected_value) do
+      Plurimath::Math::Formula.new(
+        [
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::FontStyle::Normal.new(
+              Plurimath::Math::Symbols::Symbol.new("kg"),
+              "normal",
+            ),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbols::Minus.new,
+              Plurimath::Math::Number.new("1"),
+            ])
+          ),
+          Plurimath::Math::Symbols::Cdot.new,
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::FontStyle::Normal.new(
+              Plurimath::Math::Symbols::Symbol.new("m"),
+              "normal",
+            ),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbols::Minus.new,
+              Plurimath::Math::Number.new("3"),
+            ])
+          ),
+          Plurimath::Math::Symbols::Cdot.new,
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::FontStyle::Normal.new(
+              Plurimath::Math::Symbols::Symbol.new("s"),
+              "normal",
+            ),
+            Plurimath::Math::Number.new("4"),
+          ),
+          Plurimath::Math::Symbols::Cdot.new,
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::FontStyle::Normal.new(
+              Plurimath::Math::Symbols::Symbol.new("A"),
+              "normal",
+            ),
+            Plurimath::Math::Number.new("2"),
+          ),
+        ],
+      )
+    end
+
+    it "compares expected value with to_plurimath method output" do
+      expect(formula).to eq(expected_value)
+    end
+  end
 end


### PR DESCRIPTION
This PR updates the `to_mathml` conversion method to handle nested arrays/hashes.

closes plurimath/plurimath#343