### PR TITLE
Feat: slashes between exponent numbers

### DIFF
--- a/lib/unitsml/parse.rb
+++ b/lib/unitsml/parse.rb
@@ -4,12 +4,16 @@ require "parslet"
 require "unitsml/unitsdb"
 module Unitsml
   class Parse < Parslet::Parser
-    rule(:power)    { str("^") >> intermediate_exp(number) }
-    rule(:hyphen)   { str("-") }
-    rule(:number)   { (hyphen.maybe >> match(/[0-9]/).repeat(1)).as(:integer) }
-    rule(:extender) { (str("//") | str("/") | str("*")).as(:extender) }
+    rule(:power)  { str("^") >> intermediate_exp(slashed_number) }
+    rule(:hyphen) { str("-") }
+    rule(:number) { hyphen.maybe >> match(/[0-9]/).repeat(1) }
+
+    rule(:extender) { (forward_slashes | str("*")).as(:extender) }
     rule(:sequence) { single_letter_prefixes >> units | double_letter_prefixes >> units | units }
-    rule(:unit_and_power) { units >> power.maybe }
+
+    rule(:unit_and_power)  { units >> power.maybe }
+    rule(:slashed_number)  { (number >> (forward_slashes >> number).maybe).as(:integer) }
+    rule(:forward_slashes) { str("//") | str("/") }
 
     rule(:units) do
       @@filtered_units ||= arr_to_expression(Unitsdb.units.filtered, "units")

--- a/lib/unitsml/unitsdb.rb
+++ b/lib/unitsml/unitsdb.rb
@@ -9,7 +9,7 @@ module Unitsml
       end
 
       def units
-        @@units_file ||= ::Unitsdb::Units.from_yaml(load_file((:units)))
+        @@units_file ||= ::Unitsdb::Units.from_yaml(load_file(:units))
       end
 
       def prefixes
@@ -21,7 +21,7 @@ module Unitsml
       end
 
       def quantities
-        @@quantities ||= ::Unitsdb::Quantities.from_yaml(load_file((:quantities)))
+        @@quantities ||= ::Unitsdb::Quantities.from_yaml(load_file(:quantities))
       end
 
       def prefixes_array

--- a/spec/unitsml/conv/mathml_spec.rb
+++ b/spec/unitsml/conv/mathml_spec.rb
@@ -632,7 +632,7 @@ RSpec.describe Unitsml::Parser do
         </math>
       MATHML
     end
-    it "returns parslet tree of parsed Unitsml string" do
+    it "matches MathML string" do
       expect(mathml).to be_equivalent_to(expected_value)
     end
   end

--- a/spec/unitsml/conv/mathml_spec.rb
+++ b/spec/unitsml/conv/mathml_spec.rb
@@ -591,4 +591,49 @@ RSpec.describe Unitsml::Parser do
       expect(formula.to_mathml(multiplier: :nospace)).to be_equivalent_to(nospace_expected_value)
     end
   end
+
+  context "contains plurimath/plurimath#356 Unitsml #28 example" do
+    let(:exp) { "unitsml(kg*m^-1*s^-1*K^(-1//2))" }
+
+    let(:expected_value) do
+      <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+          <mi mathvariant="normal">kg</mi>
+          <mo>&#x22c5;</mo>
+          <msup>
+            <mrow>
+              <mi mathvariant="normal">m</mi>
+            </mrow>
+            <mrow>
+              <mo>&#x2212;</mo>
+              <mn>1</mn>
+            </mrow>
+          </msup>
+          <mo>&#x22c5;</mo>
+          <msup>
+            <mrow>
+              <mi mathvariant="normal">s</mi>
+            </mrow>
+            <mrow>
+              <mo>&#x2212;</mo>
+              <mn>1</mn>
+            </mrow>
+          </msup>
+          <mo>&#x22c5;</mo>
+          <msup>
+            <mrow>
+              <mi mathvariant="normal">K</mi>
+            </mrow>
+            <mrow>
+              <mo>&#x2212;</mo>
+              <mn>1//2</mn>
+            </mrow>
+          </msup>
+        </math>
+      MATHML
+    end
+    it "returns parslet tree of parsed Unitsml string" do
+      expect(mathml).to be_equivalent_to(expected_value)
+    end
+  end
 end


### PR DESCRIPTION
This PR updates parsing rules to support slashes between exponent numbers.

closes plurimath/plurimath#356