### PR TITLE
fix: lock gemspec to use unitsdb 1.x

### DIFF
--- a/unitsml.gemspec
+++ b/unitsml.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'htmlentities'
   spec.add_dependency 'mml'
   spec.add_dependency 'parslet'
-  spec.add_dependency 'unitsdb'
+  spec.add_dependency 'unitsdb', '~>1.0'
 end


### PR DESCRIPTION
unitsdb 2.0 is released but incompatible with this gem.