### PR TITLE
Lock unitsdb to ~> 2.2.2 and mml to ~> 2.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,10 @@ gem "canon"
 gem "lutaml-model",
     github: "lutaml/lutaml-model",
     branch: "fix/global-context-register-lookup-fallback"
-gem "mml"
 gem "oga"
 gem "ox"
 gem "plurimath", github: "plurimath/plurimath",
-                 branch: "feat/autoload-and-mml-update"
+                 branch: "rt-lutaml-080"
 gem "pry"
 gem "rake"
 gem "rspec"
@@ -22,7 +21,3 @@ gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop-rspec"
 gem "simplecov"
-gem "unitsdb",
-    github: "unitsml/unitsdb-ruby",
-    branch: "feat/context-register-models",
-    submodules: true

--- a/unitsml.gemspec
+++ b/unitsml.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "htmlentities"
   spec.add_dependency "lutaml-model", "~> 0.8.0"
-  spec.add_dependency "mml", "~> 2.3.2"
+  spec.add_dependency "mml", "~> 2.3.6"
   spec.add_dependency "parslet"
-  spec.add_dependency "unitsdb", "~> 2.2.1"
+  spec.add_dependency "unitsdb", "~> 2.2.2"
 end


### PR DESCRIPTION
## Summary

- Switch `unitsdb` dependency from GitHub branch (`feat/context-register-models`) to the released `~> 2.2.2` gem from rubygems
- Bump `mml` dependency to `~> 2.3.6` to match latest resolved version
- Fixes the release workflow failure (`release #63`) caused by the git branch dependency being unavailable in CI

## Test plan

- [x] All 380 specs pass with `bundle exec rspec`