### PR TITLE
fix: drop git-source deps from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,11 @@ source "https://rubygems.org"
 gemspec
 
 gem "canon"
-gem "lutaml-model", github: "lutaml/lutaml-model", branch: "main"
 gem "nokogiri"
 gem "oga"
 gem "opal", "~> 1.8"
 gem "ox"
-gem "plurimath", github: "plurimath/plurimath", branch: "main"
+gem "plurimath", "~> 0.11.3"
 gem "pry"
 gem "rake"
 gem "rspec"


### PR DESCRIPTION
## Summary

- Drop `gem "lutaml-model", github: ...` override; fall through to gemspec `lutaml-model ~> 0.8.0`
- Replace `gem "plurimath", github: ...` with `gem "plurimath", "~> 0.11.3"`
- Verified locally: `bundle exec rake spec` → 398 examples, 0 failures

## Why

A release gem must not carry `gem "X", github: "..."` in its Gemfile: the
release CI workflow (`metanorma/ci/.github/workflows/rubygems-release.yml`)
deletes `Gemfile.lock` and re-resolves with `bundle install`, which
cannot reliably materialize git-source deps.

Both `lutaml-model` 0.8.16 and `plurimath` 0.11.3 are published on
RubyGems, so the overrides are unnecessary.

`plurimath` is not in the gemspec (it is an optional conversion
dependency — users add it to their own Gemfile if they want math
output). It must remain in this gem's Gemfile only because the spec
suite exercises `Unitsml::Formula#to_plurimath`.

## Test plan

- [x] `bundle install` resolves both from RubyGems
- [x] `bundle exec rake spec` passes (398/398)
- [ ] CI on this PR (rake workflow) passes
